### PR TITLE
Resolution of Issue #7506

### DIFF
--- a/controllers/grid/files/SubmissionFilesCategoryGridDataProvider.inc.php
+++ b/controllers/grid/files/SubmissionFilesCategoryGridDataProvider.inc.php
@@ -140,7 +140,9 @@ class SubmissionFilesCategoryGridDataProvider extends CategoryGridDataProvider
                     $note = $noteDao->getById($submissionFile->getData('assocId'));
                     assert($note && $note->getAssocType() == ASSOC_TYPE_QUERY);
                     $queryDao = DAORegistry::getDAO('QueryDAO'); /** @var QueryDAO $queryDao */
-                    $query = $queryDao->getById($note->getAssocId());
+                    if ($note) {
+                        $query = $queryDao->getById($note->getAssocId());
+                    }
                     if ($query && $query->getStageId() == $stageId) {
                         $stageSubmissionFiles[$key] = $submissionFile;
                     }


### PR DESCRIPTION
Unable to Upload/Select Files from Copyediting stage (fix ineffective) - this change extends the previous fix [https://github.com/pkp/ojs/pull/2396] to also guard the $note->GetAssocId() method call from the case where $note == null - ie. when there is an orphan note in the db